### PR TITLE
feat: Added timeout feature

### DIFF
--- a/lib/lita/handlers/totems.rb
+++ b/lib/lita/handlers/totems.rb
@@ -286,7 +286,7 @@ module Lita
         # TODO: Find a way to identify pending jobs so we can cancel them instead of letting them finish and then checking 
         if next_user_id
           timeout_hash = redis.hgetall("totem/#{totem}/timeout")
-          take_totem(response, totem, next_user_id, timeout_hash[next_user_id])
+          take_totem(response, totem, next_user_id, timeout_hash[next_user_id].to_i)
           next_user = Lita::User.find_by_id(next_user_id)
           robot.send_messages(Lita::Source.new(user: next_user), %{You are now in possession of totem "#{totem}," yielded by #{response.user.name}.})
           response.reply "You have yielded the totem to #{next_user.name}."

--- a/lib/lita/handlers/totems.rb
+++ b/lib/lita/handlers/totems.rb
@@ -6,6 +6,8 @@ module Lita
   module Handlers
     class Totems < Handler
 
+      @@DemoEnvironments = %w(cyan jade noir opal plum teal vert)
+
       def self.route_regex(action_capture_group)
         %r{
         ^totems?\s+
@@ -15,10 +17,18 @@ module Lita
         }x
       end
 
-      route(route_regex("add|join|take|queue"), :add,
-            help: {
-              'totems add TOTEM <MESSAGE>' => "Adds yourself to the TOTEM queue, or assigns yourself to the TOTEM if it's unassigned. Includes optional MESSAGE."
-            })
+      route(
+        %r{
+        ^totems?\s+
+        (add|join|take|queue)\s+
+        (?<totem>\w+)\s*
+        ((?<message>((?!timeout:).)*)\s*)?
+        (timeout:\s?(?<timeout>\d+))?
+        }x,
+        :add,
+          help: {
+            'totems add TOTEM <MESSAGE> timeout: <TIMEOUT?' => "Adds yourself to the TOTEM queue, or assigns yourself to the TOTEM if it's unassigned. Includes optional MESSAGE and optional TIMEOUT."
+      })
 
       route(
         %r{
@@ -111,26 +121,32 @@ module Lita
         end
 
         message = response.match_data[:message]
+        timeout = response.match_data[:timeout]
+        if !timeout.nil? && timeout != '0'
+          timeout = timeout.to_i
+          timeout = 24 if timeout == 0
+        else
+          timeout = 24
+        end
 
         token_acquired = false
         queue_size     = nil
         Redis::Semaphore.new("totem/#{totem}", redis: redis).lock do
           redis.hset("totem/#{totem}/message", user_id, message) if message && message != ""
+          redis.hset("totem/#{totem}/timeout", user_id, timeout) if timeout && @@DemoEnvironments.include?(totem)
           if redis.llen("totem/#{totem}/list") == 0 && redis.get("totem/#{totem}/owning_user_id").nil?
             # take it:
             token_acquired = true
-            redis.set("totem/#{totem}/owning_user_id", user_id)
-            redis.hset("totem/#{totem}/waiting_since", user_id, Time.now.to_i)
+            take_totem(response, totem, user_id, timeout)
           else
             # queue:
             queue_size = redis.rpush("totem/#{totem}/list", user_id)
             redis.hset("totem/#{totem}/waiting_since", user_id, Time.now.to_i)
           end
         end
-
+        
         if token_acquired
           # TODO don't readd to totems you are already waiting for!
-          redis.sadd("user/#{user_id}/totems", totem)
           response.reply(%{#{response.user.name}, you now have totem "#{totem}".})
         else
           response.reply(%{#{response.user.name}, you are \##{queue_size} in line for totem "#{totem}".})
@@ -157,6 +173,7 @@ module Lita
               redis.lrem("totem/#{totem_specified}/list", 0, user_id)
               redis.hdel("totem/#{totem_specified}/waiting_since", user_id)
               redis.hdel("totem/#{totem_specified}/message", user_id)
+              redis.hdel("totem/#{totem}/timeout", user_id)
               response.reply("You are no longer in line for the \"#{totem_specified}\" totem.")
             else
               response.reply %{Error: You don't own and aren't waiting for the "#{totem_specified}" totem.}
@@ -223,8 +240,10 @@ module Lita
         if first_id
           waiting_since_hash = redis.hgetall("totem/#{totem}/waiting_since")
           message_hash = redis.hgetall("totem/#{totem}/message")
+          timeout_hash = redis.hgetall("totem/#{totem}/timeout")
           str += "#{prefix}1. #{users_cache[first_id].name} (held for #{waiting_duration(waiting_since_hash[first_id])})"
           str += " - #{message_hash[first_id]}" if message_hash[first_id]
+          str += " - timeout: #{timeout_hash[first_id]}" if timeout_hash[first_id]
           str += "\n"
           rest = redis.lrange("totem/#{totem}/list", 0, -1)
           rest.each_with_index do |user_id, index|
@@ -240,15 +259,33 @@ module Lita
         ChronicDuration.output(Time.now.to_i - time.to_i, format: :short) || "0s"
       end
 
+      def take_totem(response, totem, user_id, timeout)
+        redis.set("totem/#{totem}/owning_user_id", user_id)
+        redis.sadd("user/#{user_id}/totems", totem)
+        redis.hset("totem/#{totem}/waiting_since", user_id, Time.now.to_i)
+        if @@DemoEnvironments.include? totem
+          # Create async job
+          after(timeout) do |timer|
+            # Check that the user is the current owner of the totem
+            current_owner = redis.get("totem/#{totem}/owning_user_id")
+            if user_id == current_owner
+              yield_totem(response.match_data[:totem], user_id, response)
+            end
+          end
+        end
+      end
+
       def yield_totem(totem, user_id, response)
         redis.srem("user/#{user_id}/totems", totem)
         redis.hdel("totem/#{totem}/waiting_since", user_id)
         redis.hdel("totem/#{totem}/message", user_id)
+        redis.hdel("totem/#{totem}/timeout", user_id)
         next_user_id = redis.lpop("totem/#{totem}/list")
+        # TODO: Remove async job
+        # TODO: Find a way to identify pending jobs so we can cancel them instead of letting them finish and then checking 
         if next_user_id
-          redis.set("totem/#{totem}/owning_user_id", next_user_id)
-          redis.sadd("user/#{next_user_id}/totems", totem)
-          redis.hset("totem/#{totem}/waiting_since", next_user_id, Time.now.to_i)
+          timeout_hash = redis.hgetall("totem/#{totem}/timeout")
+          take_totem(response, totem, next_user_id, timeout_hash[next_user_id])
           next_user = Lita::User.find_by_id(next_user_id)
           robot.send_messages(Lita::Source.new(user: next_user), %{You are now in possession of totem "#{totem}," yielded by #{response.user.name}.})
           response.reply "You have yielded the totem to #{next_user.name}."

--- a/lib/lita/handlers/totems.rb
+++ b/lib/lita/handlers/totems.rb
@@ -74,7 +74,7 @@ module Lita
 
       def destroy(response)
         totem = response.match_data[:totem]
-        if redis.exists("totem/#{totem}") != 0
+        if totem_exists? redis, totem
           redis.del("totem/#{totem}")
           redis.del("totem/#{totem}/list")
           redis.srem("totems", totem)
@@ -91,7 +91,7 @@ module Lita
       def create(response)
         totem = response.match_data[:totem]
 
-        if redis.exists("totem/#{totem}") != 0
+        if totem_exists? redis, totem
           response.reply %{Error: totem "#{totem}" already exists.}
         else
           redis.set("totem/#{totem}", 1)
@@ -103,7 +103,7 @@ module Lita
 
       def add(response)
         totem = response.match_data[:totem]
-        unless redis.exists("totem/#{totem}") != 0
+        unless totem_exists? redis, totem
           response.reply %{Error: there is no totem "#{totem}".}
           return
         end
@@ -186,7 +186,7 @@ module Lita
 
       def kick(response)
         totem = response.match_data[:totem]
-        unless redis.exists("totem/#{totem}") != 0
+        unless totem_exists? redis, totem
           response.reply %{Error: there is no totem "#{totem}".}
           return
         end
@@ -230,6 +230,10 @@ module Lita
       end
 
       private
+      def totem_exists?(redis, totem)
+        redis.exists("totem/#{totem}") != 0
+      end
+
       def new_users_cache
         Hash.new { |h, id| h[id] = Lita::User.find_by_id(id) }
       end

--- a/lib/lita/handlers/totems.rb
+++ b/lib/lita/handlers/totems.rb
@@ -286,7 +286,7 @@ module Lita
         redis.hset("totem/#{totem}/waiting_since", user_id, Time.now.to_i)
         if @@DemoEnvironments.include? totem
           # Create async job
-          after(timeout) do |timer|
+          after(timeout*3600) do |timer|
             # Check that the user is the current owner of the totem
             current_owner = redis.get("totem/#{totem}/owning_user_id")
             if user_id == current_owner

--- a/lita-totems.gemspec
+++ b/lita-totems.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "timecop"
   spec.add_development_dependency "coveralls"
+  spec.add_development_dependency "rspec-wait"
 end

--- a/spec/lita/handlers/totems_spec.rb
+++ b/spec/lita/handlers/totems_spec.rb
@@ -129,14 +129,12 @@ describe Lita::Handlers::Totems, lita_handler: true do
       end
 
       context "with a timeout" do
-        before do
+        it "includes the timeout in the totems' info" do
           Timecop.freeze("2014-03-01 12:00:00") do
             send_message("totems add noir timeout: 10", as: carl)
             send_message("totems add noir", as: another_user)
             send_message("totems add noir timeout: 20", as: yet_another_user)
           end
-        end
-        it "includes the timeout in the totems' info" do
           Timecop.freeze("2014-03-01 13:00:00") do
             send_message("totems info noir")
             expect(replies.last).to eq <<-END
@@ -148,11 +146,19 @@ describe Lita::Handlers::Totems, lita_handler: true do
         end
 
         it "triggers the timeout when the totem is in the list" do
-          send_message("totems add noir timeout: 10", as: carl)
+          send_message("totems add noir timeout: 3", as: carl)
+          wait(10).for do
+              send_message("totems info noir")
+              replies.last.empty?
+          end.to be(true)
         end
 
         it "doesn't trigger the timeout on any totem" do
-          send_message("totems add chicken timeout: 10", as: carl)
+          send_message("totems add chicken timeout: 3", as: carl)
+          wait(10).for do
+              send_message("totems info chicken")
+              replies.last
+          end.to eq("1. Carl (held for 5s)\n")
         end
       end
 

--- a/spec/lita/handlers/totems_spec.rb
+++ b/spec/lita/handlers/totems_spec.rb
@@ -7,6 +7,10 @@ describe Lita::Handlers::Totems, lita_handler: true do
   it { is_expected.to route("totems add foo message").to(:add) }
   it { is_expected.not_to route("totems add ").to(:add) }
   it { is_expected.not_to route("tote add foo").to(:add) }
+  it { is_expected.to route("totems add chicken timeout: 10").to(:add) }
+  it { is_expected.to route("totems add chicken timeout: 20").to(:add) }
+  it { is_expected.to route("totems add chicken message timeout: 10").to(:add) }
+  it { is_expected.to route("totems add chicken other message timeout:20").to(:add) }
   it { is_expected.to route("totems kick foo").to(:kick) }
   it { is_expected.to route("totems kick foo bob").to(:kick) }
   it { is_expected.to route("totems").to(:info) }
@@ -127,20 +131,28 @@ describe Lita::Handlers::Totems, lita_handler: true do
       context "with a timeout" do
         before do
           Timecop.freeze("2014-03-01 12:00:00") do
-            send_message("totems add chicken timeout: 10", as: carl)
-            send_message("totems add chicken", as: another_user)
-            send_message("totems add chicken timeout: 20", as: yet_another_user)
+            send_message("totems add noir timeout: 10", as: carl)
+            send_message("totems add noir", as: another_user)
+            send_message("totems add noir timeout: 20", as: yet_another_user)
           end
         end
         it "includes the timeout in the totems' info" do
           Timecop.freeze("2014-03-01 13:00:00") do
-            send_message("totems info chicken")
+            send_message("totems info noir")
             expect(replies.last).to eq <<-END
 1. Carl (held for 1h) - timeout: 10
 2. person_1 (waiting for 1h) - timeout: 24
 3. person_2 (waiting for 1h) - timeout: 20
             END
           end
+        end
+
+        it "triggers the timeout when the totem is in the list" do
+          send_message("totems add noir timeout: 10", as: carl)
+        end
+
+        it "doesn't trigger the timeout on any totem" do
+          send_message("totems add chicken timeout: 10", as: carl)
         end
       end
 
@@ -167,14 +179,14 @@ describe Lita::Handlers::Totems, lita_handler: true do
       context "with a message and a timeout" do
         before do
           Timecop.freeze("2014-03-01 12:00:00") do
-            send_message("totems add chicken message timeout: 10", as: carl)
-            send_message("totems add chicken", as: another_user)
-            send_message("totems add chicken other message timeout:20", as: yet_another_user)
+            send_message("totems add noir message timeout: 10", as: carl)
+            send_message("totems add noir", as: another_user)
+            send_message("totems add noir other message timeout:20", as: yet_another_user)
           end
         end
         it "includes the timeout and the message in the totems' info" do
           Timecop.freeze("2014-03-01 13:00:00") do
-            send_message("totems info chicken")
+            send_message("totems info noir")
             expect(replies.last).to eq <<-END
 1. Carl (held for 1h) - message - timeout: 10
 2. person_1 (waiting for 1h) - timeout: 24

--- a/spec/lita/handlers/totems_spec.rb
+++ b/spec/lita/handlers/totems_spec.rb
@@ -205,7 +205,7 @@ describe Lita::Handlers::Totems, lita_handler: true do
           end.to be(true)
         end
 
-        it "doesn't trigger the timeout on any totem" do
+        it "doesn't trigger timeout when the totem is not on a demo environment" do
           send_message("totems add chicken timeout: 3", as: carl)
           wait(10).for do
               send_message("totems info chicken")

--- a/spec/lita/handlers/totems_spec.rb
+++ b/spec/lita/handlers/totems_spec.rb
@@ -196,6 +196,7 @@ describe Lita::Handlers::Totems, lita_handler: true do
           end
         end
 
+        # These two tests require that the multiplication is removed from the timeout
         it "triggers the timeout when the totem is in the list" do
           send_message("totems add noir timeout: 3", as: carl)
           wait(10).for do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,4 +9,5 @@ SimpleCov.start { add_filter "/spec/" }
 
 require "lita-totems"
 require "lita/rspec"
+require "rspec/wait"
 Lita.version_3_compatibility_mode = false


### PR DESCRIPTION
A timeout feature was added using the already existing functionality
this functionality uses threads so it doesn't allow us to cancel the job once we exist its creation context, so we can't cancel it when the totems is yield

@change/squad-starter-growth @change/squad-starter-growth 